### PR TITLE
This fix repository cloning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in gitolite.gemspec
 gemspec
-gem 'rugged', git: 'git://github.com/libgit2/rugged.git', branch: 'development', submodules: true
+gem 'rugged', :github => 'libgit2/rugged', :tag => 'v0.21.0', :submodules => true

--- a/gitolite.gemspec
+++ b/gitolite.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec_junit_formatter", "~> 0.1", ">= 0.1.6"
 
-  s.add_dependency "rugged", "~> 0.19",   ">= 0.19.0"
+  s.add_dependency "rugged", "~> 0.21",   ">= 0.21.0"
   s.add_dependency "gratr19", "~> 0.4.4", ">= 0.4.4.1"
 
   s.files         = `git ls-files`.split("\n")

--- a/gitolite.gemspec
+++ b/gitolite.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec_junit_formatter", "~> 0.1", ">= 0.1.6"
 
-  s.add_dependency "rugged", "~> 0.21",   ">= 0.21.0"
+  s.add_dependency "rugged", "~> 0.21.0", ">= 0.21.0"
   s.add_dependency "gratr19", "~> 0.4.4", ">= 0.4.4.1"
 
   s.files         = `git ls-files`.split("\n")

--- a/gitolite.gemspec
+++ b/gitolite.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec_junit_formatter", "~> 0.1", ">= 0.1.6"
 
-  s.add_dependency "rugged", "~> 0.21.0", ">= 0.21.0"
+  s.add_dependency "rugged", "~> 0.21", ">= 0.21.0"
   s.add_dependency "gratr19", "~> 0.4.4", ">= 0.4.4.1"
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -79,8 +79,10 @@ module Gitolite
 
       # setup credentials
       @credentials = Rugged::Credentials::SshKey.new(
-        username: settings[:git_user], publickey: settings[:public_key],
-        privatekey: settings[:private_key] )
+        username: @settings[:git_user],
+        publickey: settings[:public_key],
+        privatekey: settings[:private_key]
+      )
 
       @repo =
       if self.class.is_gitolite_admin_repo?(path)

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -79,9 +79,9 @@ module Gitolite
 
       # setup credentials
       @credentials = Rugged::Credentials::SshKey.new(
-        username: settings[:git_user], publickey: settings[:public_key], 
+        username: settings[:git_user], publickey: settings[:public_key],
         privatekey: settings[:private_key] )
-      
+
       @repo =
       if self.class.is_gitolite_admin_repo?(path)
         Rugged::Repository.new(path, credentials: @credentials)
@@ -201,7 +201,7 @@ module Gitolite
       commit_tree = index.write_tree @repo
       index.write
 
-      commit_author = { email: 'wee@example.org', name: 'gitolite-rugged gem', time: Time.now }
+      commit_author = @commit_author.merge(time: Time.now)
 
       Rugged::Commit.create(@repo,
         author: commit_author,

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -46,7 +46,7 @@ module Gitolite
       end
 
       def admin_url(settings)
-        [settings[:git_user], '@', settings[:host], '/gitolite-admin.git'].join
+        ['ssh://', settings[:git_user], '@', settings[:host], '/gitolite-admin.git'].join
       end
     end
 
@@ -278,7 +278,7 @@ module Gitolite
     # The hostname may use an optional :port to allow for custom SSH ports.
     # E.g., +git@localhost:2222/gitolite-admin.git+
     #
-    def clone()
+    def clone
       Rugged::Repository.clone_at(GitoliteAdmin.admin_url(@settings), File.expand_path(@path), credentials: @credentials)
     end
 

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -93,7 +93,7 @@ module Gitolite
       @config_file_path = File.join(@config_dir_path, @settings[:config_file])
       @key_dir_path     = File.join(@path, relative_key_dir)
 
-      @commit_author = { email: settings[:author_email], name: settings[:author_name] }
+      @commit_author = { email: @settings[:author_email], name: @settings[:author_name] }
 
       reload!
     end

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -279,7 +279,7 @@ module Gitolite
     # E.g., +git@localhost:2222/gitolite-admin.git+
     #
     def clone()
-      Rugged::Repository.clone_at(admin_url(@settings), File.expand_path(@path), credentials: @credentials)
+      Rugged::Repository.clone_at(GitoliteAdmin.admin_url(@settings), File.expand_path(@path), credentials: @credentials)
     end
 
 

--- a/lib/gitolite/gitolite_admin.rb
+++ b/lib/gitolite/gitolite_admin.rb
@@ -33,7 +33,7 @@ module Gitolite
         begin
           repo = Rugged::Repository.new(dir)
           return false if repo.empty?
-        rescue Rugged::RepositoryError
+        rescue Rugged::RepositoryError, Rugged::OSError
           return false
         end
 

--- a/spec/dirty_proxy_spec.rb
+++ b/spec/dirty_proxy_spec.rb
@@ -28,27 +28,27 @@ describe Gitolite::DirtyProxy do
 
   describe 'dirty checking methods' do
     it 'should respond to clean_up!' do
-      proxy.respond_to?(:clean_up!).should be_true
+      proxy.respond_to?(:clean_up!).should be true
     end
 
     it 'should respond to dirty?' do
-      proxy.respond_to?(:dirty?).should be_true
+      proxy.respond_to?(:dirty?).should be true
     end
 
     context 'when just initialized' do
       it 'should be clean' do
-        proxy.dirty?.should be_false
+        proxy.dirty?.should be false
       end
     end
 
     shared_examples 'dirty? clean_up!' do
       it 'should be dirty' do
-        proxy.dirty?.should be_true
+        proxy.dirty?.should be true
       end
 
       it 'should be clean again after clean_up!' do
         proxy.clean_up!
-        proxy.dirty?.should be_false
+        proxy.dirty?.should be false
       end
     end
 


### PR DESCRIPTION
You need to specify the url scheme if you want to pass the SSH server port.
If not you got :

```
Rugged::NetworkError (Early EOF):
  /data/redmine-repositories/jbox/.rvm/gems/ruby-2.0.0-p451/bundler/gems/gitolite-rugged-5dbfc8ad70cb/lib/gitolite/gitolite_admin.rb:286:in `clone_at'
  /data/redmine-repositories/jbox/.rvm/gems/ruby-2.0.0-p451/bundler/gems/gitolite-rugged-5dbfc8ad70cb/lib/gitolite/gitolite_admin.rb:286:in `clone'
  /data/redmine-repositories/jbox/.rvm/gems/ruby-2.0.0-p451/bundler/gems/gitolite-rugged-5dbfc8ad70cb/lib/gitolite/gitolite_admin.rb:89:in `initialize'
```
